### PR TITLE
Fixes `Semaphore` and `mpsc` channel closing

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -497,7 +497,7 @@ impl<T> Clone for Sender<T> {
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         // SAFETY: no mutable or aliased access to shared possible
-        unsafe { (*self.shared.0.get()).mask.decrease_sender_count() };
+        unsafe { (*self.shared.0.get()).decrease_sender_count() };
     }
 }
 
@@ -658,7 +658,7 @@ impl<T> Clone for SenderRef<'_, T> {
 impl<T> Drop for SenderRef<'_, T> {
     fn drop(&mut self) {
         // SAFETY: no mutable or aliased access to shared possible
-        unsafe { (*self.shared.0.get()).mask.decrease_sender_count() };
+        unsafe { (*self.shared.0.get()).decrease_sender_count() };
     }
 }
 
@@ -1058,7 +1058,8 @@ mod tests {
             assert_eq!(tx.capacity(), 0);
 
             // polling the second send first should still return pending, even
-            // though there is room in the queue
+            // though there is room in the queue, because the order has been
+            // established when the futures were first registered
             core::future::poll_fn(|cx| {
                 assert!(s2.as_mut().poll(cx).is_pending());
                 assert_eq!(s1.as_mut().poll(cx), Poll::Ready(Ok(())));

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -214,7 +214,7 @@ impl<T> UnsyncShared<T, Bounded> {
 
     pub(crate) fn unreserve(&self) {
         // SAFETY: no mutable or aliased access to shared possible
-        drop(unsafe { (*self.0.get()).extra.semaphore.make_permit() });
+        drop(unsafe { (*self.0.get()).extra.semaphore.make_permit(1) });
     }
 }
 
@@ -230,6 +230,14 @@ pub(crate) struct Shared<T, B = Unbounded> {
 }
 
 impl<T, B> Shared<T, B> {
+    pub(crate) fn decrease_sender_count(&mut self) {
+        if self.mask.decrease_sender_count() {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
     /// Pushes `elem` to the back of the queue and wakes the registered
     /// waker if set.
     fn push_and_wake(&mut self, elem: T) {
@@ -338,9 +346,9 @@ pub trait MaybeBoundedQueue {
     fn try_recv<const COUNTED: bool>(&mut self) -> Result<Self::Item, TryRecvError>;
 }
 
-pub struct Unbounded;
+pub(crate) struct Unbounded;
 
-pub struct Bounded {
+pub(crate) struct Bounded {
     /// The semaphore sequencing the blocked senders.
     semaphore: Semaphore,
     /// The channel's capacity.

--- a/src/unbounded.rs
+++ b/src/unbounded.rs
@@ -201,7 +201,7 @@ impl<T> Clone for UnboundedSender<T> {
 impl<T> Drop for UnboundedSender<T> {
     fn drop(&mut self) {
         // SAFETY: no mutable or aliased access to shared possible
-        unsafe { (*self.shared.0.get()).mask.decrease_sender_count() };
+        unsafe { (*self.shared.0.get()).decrease_sender_count() };
     }
 }
 
@@ -274,7 +274,7 @@ impl<T> Clone for UnboundedSenderRef<'_, T> {
 impl<T> Drop for UnboundedSenderRef<'_, T> {
     fn drop(&mut self) {
         // SAFETY: no mutable or aliased access to shared possible
-        unsafe { (*self.shared.0.get()).mask.decrease_sender_count() };
+        unsafe { (*self.shared.0.get()).decrease_sender_count() };
     }
 }
 

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -1,0 +1,36 @@
+use async_unsync::bounded;
+use futures_lite::future;
+
+#[test]
+fn mpsc() {
+    future::block_on(async {
+        let mut chan = bounded::channel(1);
+        let (tx, mut rx) = chan.split();
+
+        let f1 = future::zip(push_loop(tx.clone(), 1), push_loop(tx, 2));
+        let f2 = async move {
+            let mut vec = vec![];
+            while let Some(id) = rx.recv().await {
+                vec.push(id);
+                if vec.len() == 10 {
+                    rx.close();
+                }
+            }
+
+            vec
+        };
+
+        let (_, res) = future::zip(f1, f2).await;
+        assert_eq!(res, &[1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);
+    })
+}
+
+async fn push_loop(tx: bounded::SenderRef<'_, i32>, id: i32) {
+    let mut count = 0;
+    while let Ok(_) = tx.send(id).await {
+        futures_lite::future::yield_now().await;
+        count += 1;
+    }
+
+    assert_eq!(count, 5);
+}


### PR DESCRIPTION
This commit fixes two issues:

- closing a `Semaphore` would not return all acquired permits back to the Semaphore correctly
- closing or dropping the last Sender would not notify a waiting Receiver correctly

This involves basically a complete `Semaphore`
rewrite, which now implements an intrusive linked
list of waiters, instead of using an internal
(allocating) `VecDeque`.

fix `Sender[Ref]::drop`, so that final drop correctly wakes Receiver

preliminary fix for the issue (miri complains!)

preliminary fix to soundness issue

refactor intrusive semaphore

fix fully implemented